### PR TITLE
update ansible roles to recent releases in galaxy

### DIFF
--- a/ansible/plays/osstracker.yml
+++ b/ansible/plays/osstracker.yml
@@ -4,7 +4,7 @@
   hosts: osstracker
   become: true
   roles:
-    - tersmitten.locales
+    - oefenweb.locales
   tasks:
     - name: Run the equivalent of "apt-get update" as a separate step
       apt:
@@ -38,7 +38,8 @@
 - name: Install Docker Compose
   hosts: osstracker
   roles:
-    - Bessonov.docker-compose
+      - role: Bessonov.docker-compose
+        docker_compose_version: latest
 
 - name: Deploy OSSTracker
   hosts: osstracker

--- a/ansible/roles/roles_requirements.yml
+++ b/ansible/roles/roles_requirements.yml
@@ -6,4 +6,4 @@
   #version: "v1.0.1"
   name: Bessonov.docker-compose
 
-- name: tersmitten.locales
+- name: oefenweb.locales


### PR DESCRIPTION
Updated two roles in `osstracker.yml` based on their updated releases in Ansible Galaxy.

`tersmitten.locales` does not exist in Ansible Galasy. `oefenweb.locales` is the proper role.
[Reference Issue #11](https://github.com/Oefenweb/ansible-locales/issues/11).

Bessonov now requires `docker_compose_version ` as a parameter.
[Reference](https://github.com/Bessonov/ansible-role-docker-compose)